### PR TITLE
[webhook] Allow pusher email to be null

### DIFF
--- a/src/api/repos/file.rs
+++ b/src/api/repos/file.rs
@@ -241,12 +241,12 @@ mod tests {
             .branch("not-master")
             .commiter(CommitAuthor {
                 name: "Octocat".to_string(),
-                email: "octocat@github.com".to_string(),
+                email: Some("octocat@github.com".to_string()),
                 date: None,
             })
             .author(CommitAuthor {
                 name: "Ferris".to_string(),
-                email: "ferris@rust-lang.org".to_string(),
+                email: Some("ferris@rust-lang.org".to_string()),
                 date: None,
             });
 
@@ -280,12 +280,12 @@ mod tests {
             .branch("not-master")
             .commiter(CommitAuthor {
                 name: "Octocat".to_string(),
-                email: "octocat@github.com".to_string(),
+                email: Some("octocat@github.com".to_string()),
                 date: None,
             })
             .author(CommitAuthor {
                 name: "Ferris".to_string(),
-                email: "ferris@rust-lang.org".to_string(),
+                email: Some("ferris@rust-lang.org".to_string()),
                 date: None,
             });
 

--- a/src/models/events/payload/push.rs
+++ b/src/models/events/payload/push.rs
@@ -45,7 +45,7 @@ mod test {
                     commit.author,
                     CommitAuthor {
                         name: "readme-bot".to_string(),
-                        email: "readme-bot@example.com".to_string(),
+                        email: Some("readme-bot@example.com".to_string()),
                         date: None,
                     }
                 );

--- a/src/models/repos.rs
+++ b/src/models/repos.rs
@@ -155,7 +155,7 @@ pub struct GitUserTime {
 #[serde(rename_all = "snake_case")]
 pub struct CommitAuthor {
     pub name: String,
-    pub email: String,
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<DateTime<Utc>>,
 }


### PR DESCRIPTION
## Description
* See https://github.com/XAMPPRocky/octocrab/issues/486
* https://docs.github.com/en/webhooks/webhook-events-and-payloads#push 
  * GitHub allows null email

## Test Plan
* CI

## Revert Plan
* Revert
