### PR TITLE
[octocrab] Adding ability to create and react on review comment itself

### DIFF
--- a/src/api/pulls.rs
+++ b/src/api/pulls.rs
@@ -13,7 +13,7 @@ use crate::pulls::specific_pr::{SpecificPullRequestBuilder, SpecificPullRequestC
 use crate::{Octocrab, Page};
 
 pub use self::{
-    create::CreatePullRequestBuilder, list::ListPullRequestsBuilder,
+    comment::CreateCommentBuilder, create::CreatePullRequestBuilder, list::ListPullRequestsBuilder,
     update::UpdatePullRequestBuilder,
 };
 
@@ -375,6 +375,37 @@ impl<'octo> PullRequestHandler<'octo> {
     /// ```
     pub fn list_comments(&self, pr: Option<u64>) -> comment::ListCommentsBuilder {
         comment::ListCommentsBuilder::new(self, pr)
+    }
+
+    /// Creates a new `CreateCommentBuilder` that can be configured to create a
+    /// new `Comment` on a particular pull request.
+    /// ```no_run
+    /// # async fn run() -> octocrab::Result<()> {
+    /// # let octocrab = octocrab::Octocrab::default();
+    /// use octocrab::params;
+    ///
+    /// let comment = octocrab.pulls("owner", "repo").create_comment(5, "commit_id", "body", "path")
+    ///     // Optional Parameters
+    ///     .position(5)
+    ///     .line(5)
+    ///     .side(params::pulls::CommentSide::Right)
+    ///     .start_line(5)
+    ///     .start_side(params::pulls::CommentSide::Right)
+    ///     .in_reply_to(5)
+    ///     // Send the request
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create_comment(
+        &self,
+        pr: u64,
+        commit_id: String,
+        body: String,
+        path: String,
+    ) -> CreateCommentBuilder<'_, '_> {
+        CreateCommentBuilder::new(self, pr, commit_id, body.into(), path)
     }
 
     ///creates a new `CommentBuilder` for GET/PATCH/DELETE requests

--- a/src/api/pulls/comment.rs
+++ b/src/api/pulls/comment.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use crate::models::pulls::Comment;
+use crate::models::{self, pulls::Comment, reactions::Reaction};
 
 use super::*;
 
@@ -136,6 +136,25 @@ impl<'octo, 'b> CommentBuilder<'octo, 'b> {
                     comment_id = self.comment_id
                 ),
                 Some(&json!({ "body": comment })),
+            )
+            .await
+    }
+
+    ///https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-a-pull-request-review-comment
+    pub async fn react(
+        self,
+        reaction: models::reactions::ReactionContent,
+    ) -> crate::Result<Reaction> {
+        self.handler
+            .crab
+            .post(
+                format!(
+                    "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+                    owner = self.handler.owner,
+                    repo = self.handler.repo,
+                    comment_id = self.comment_id
+                ),
+                Some(&json!({ "content": reaction })),
             )
             .await
     }

--- a/src/api/pulls/comment.rs
+++ b/src/api/pulls/comment.rs
@@ -159,6 +159,24 @@ impl<'octo, 'b> CommentBuilder<'octo, 'b> {
             .await
     }
 
+    ///https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#delete-a-pull-request-comment-reaction
+    pub async fn delete_react(self, reaction_id: u64) -> crate::Result<()> {
+        self.handler
+            .crab
+            ._delete(
+                format!(
+                    "/repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}",
+                    owner = self.handler.owner,
+                    repo = self.handler.repo,
+                    comment_id = self.comment_id,
+                    reaction_id = reaction_id
+                ),
+                None::<&()>,
+            )
+            .await?;
+        Ok(())
+    }
+
     ///https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#delete-a-review-comment-for-a-pull-request
     pub async fn delete(self) -> crate::Result<()> {
         self.handler


### PR DESCRIPTION
## Description
* Exposing latest api from https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#create-a-review-comment-for-a-pull-request to create a review comment
* Exposing latest api from https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-a-pull-request-review-comment to react to review comments

## Test Plan
* Verified with DJ - https://github.com/gitarcode/gitar/pull/2613

## Revert Plan
* Revert