### PR TITLE
[installation] Add installation to the installation event webhook

### DIFF
--- a/src/models/webhook_events/payload/installation.rs
+++ b/src/models/webhook_events/payload/installation.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::models::webhook_events::InstallationEventRepository;
+use crate::models::{webhook_events::InstallationEventRepository, Installation};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct InstallationWebhookEventPayload {
     pub action: InstallationWebhookEventAction,
     pub enterprise: Option<serde_json::Value>,
+    pub installation: Installation,
     #[serde(default)]
     pub repositories: Option<Vec<InstallationEventRepository>>,
     pub requester: Option<serde_json::Value>,


### PR DESCRIPTION
## Description
* The installation object is mandatory in the Installation Webhook Event, so we can serialize this from the payload.
* This is useful for extracting the installed organization ID

## Test Plan
* Testing on CI

## Revert Plan
* Revert