### PR TITLE
[octocrab][status] Adding empty is none for target_url

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -443,6 +443,22 @@ where
     }
 }
 
+/// If a URL string is empty then deserialize it as none
+pub fn empty_url_is_none<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // try to deserialize our input string
+    let cast = String::deserialize(deserializer)?;
+    // if this string is empty then return None
+    if cast.is_empty() {
+        Ok(None)
+    } else {
+        // try to parse the string as a URL
+        Url::parse(&cast).map(Some).map_err(de::Error::custom)
+    }
+}
+
 /// The full profile for a user
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]

--- a/src/models/webhook_events/payload/status.rs
+++ b/src/models/webhook_events/payload/status.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::models::StatusId;
+use crate::models::{empty_url_is_none, StatusId};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct StatusWebhookEventPayload {
+    #[serde(deserialize_with = "empty_url_is_none")]
     pub avatar_url: Option<Url>,
     pub branches: Vec<serde_json::Value>,
     pub commit: serde_json::Value,
@@ -17,6 +18,7 @@ pub struct StatusWebhookEventPayload {
     pub name: String,
     pub sha: String,
     pub state: CommitState,
+    #[serde(deserialize_with = "empty_url_is_none")]
     pub target_url: Option<Url>,
     pub updated_at: String,
 }


### PR DESCRIPTION
## Description
* Add a new deserializer to treat empty url as None
* Adding it to points in octocrab that we use today is causing issues, we can spread this out further in a subsequent PR once we confirm this works for our usecases

## Test Plan
* Will be testing on prod

## Revert Plan
* Revert