### PR TITLE
fix: make Author.url Optional to handle empty strings from GitHub API

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -439,7 +439,10 @@ pub struct Author {
     pub node_id: String,
     pub avatar_url: Url,
     pub gravatar_id: String,
-    pub url: Url,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub url: Option<Url>,
     pub html_url: Url,
     pub followers_url: Url,
     pub following_url: Url,


### PR DESCRIPTION
## Description

GitHub sometimes returns an empty string for `app.owner.url` in check run responses. This causes octocrab deserialization to fail with `relative URL without a base: ""`, which cascades to a 500 on `/internal/pr/info?output=detailed` for affected orgs (e.g. securityscorecard).

Changes `Author.url` from `Url` to `Option<Url>` using the existing `empty_url_is_none` deserializer.

## Test Plan

Bake on staging after bumping the octocrab rev in gitar. Verify backstage PR info loads for securityscorecard repos.

## Revert Plan

Revert diff