### PR TITLE
fix: make remaining Author URL fields Optional for enterprise owners

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -443,16 +443,46 @@ pub struct Author {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub url: Option<Url>,
-    pub html_url: Url,
-    pub followers_url: Url,
-    pub following_url: Url,
-    pub gists_url: Url,
-    pub starred_url: Url,
-    pub subscriptions_url: Url,
-    pub organizations_url: Url,
-    pub repos_url: Url,
-    pub events_url: Url,
-    pub received_events_url: Url,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub html_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub followers_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub following_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub gists_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub starred_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub subscriptions_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub organizations_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub repos_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub events_url: Option<Url>,
+    #[serde(default, deserialize_with = "empty_url_is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub received_events_url: Option<Url>,
     pub r#type: String,
     pub site_admin: bool,
     #[builder(default)]


### PR DESCRIPTION
## Description

Extends #18 (248f025). GitHub returns empty strings for `html_url`, `followers_url`, `following_url`, `gists_url`, `starred_url`, `subscriptions_url`, `organizations_url`, `repos_url`, `events_url`, and `received_events_url` when the owner's `type` is `"enterprise"` (e.g. apps installed into enterprise-owned repos). The previous patch only relaxed `url`, so the rest still fail deserialization with `relative URL without a base: ""`.

This surfaced as a `check_run` webhook parse failure in gitar — a check_run with `"success"` conclusion caused the whole handler to error out. Any `failure` check_run from the same apps would fail too.

## Changes

Applies the same `empty_url_is_none` + `Option<Url>` treatment to each of those fields.

## Test Plan

- Octocrab lib tests pass (107/107).
- Gitar3 workspace compiles clean on the bumped rev.
- Bake on staging after bumping the octocrab rev in gitar.

## Revert Plan

Revert diff.