### PR TITLE
Make PushWebhookEventPayload.compare optional

### DIFF
--- a/src/models/webhook_events/payload/push.rs
+++ b/src/models/webhook_events/payload/push.rs
@@ -12,7 +12,7 @@ pub struct PushWebhookEventPayload {
     pub base_ref: Option<String>,
     pub before: String,
     pub commits: Vec<PushWebhookEventCommit>,
-    pub compare: Url,
+    pub compare: Option<Url>,
     pub created: bool,
     pub deleted: bool,
     pub forced: bool,


### PR DESCRIPTION
## Summary
- Change `compare: Url` to `compare: Option<Url>` in `PushWebhookEventPayload`
- GitHub sends `"compare": null` on certain force-pushes with zero commits, which fails deserialization when the field is typed as `Url`

## Test plan
- Existing tests should pass (no code reads this field)
- Verified in gitar codebase: `payload.compare` is never accessed for push events

Made with [Cursor](https://cursor.com)